### PR TITLE
Rail SDK : Opening an uploaded file throws "Template is missing"

### DIFF
--- a/app/controllers/froala_controller.rb
+++ b/app/controllers/froala_controller.rb
@@ -1,5 +1,7 @@
 class FroalaController < ActionController::Base
 
+  VIDEO_EXT = [".mp4", ".webm", ".ogg"]
+  FILE_EXT = [".txt",".json",".html",".pdf",".doc"]
   # Index.
   def index
     options = {
@@ -101,8 +103,18 @@ class FroalaController < ActionController::Base
 
   # Access uploaded files.
   def access_file
-    if File.exists?(Rails.root.join('public', 'uploads', 'images', params[:name]))
-      File.open(Rails.root.join('public', 'uploads', 'images', params[:name]), 'rb') do |f|
+    ext = File.extname(params[:name])
+
+    if(VIDEO_EXT.include?(ext))
+      fileUploadFolder = 'videos'
+    elsif(FILE_EXT.include?(ext))
+      fileUploadFolder = 'files'
+    else
+      fileUploadFolder = 'images'  
+    end
+
+    if File.exists?(Rails.root.join('public', 'uploads', fileUploadFolder , params[:name]))
+      File.open(Rails.root.join('public', 'uploads', fileUploadFolder , params[:name]), 'rb') do |f|
         send_data f.read, :filename => ::File.basename(params[:name]), :disposition => "inline"
       end
     else


### PR DESCRIPTION
Issue: https://github.com/froala-labs/froala-editor-js-2/issues/2553
Description : Opening an uploaded file throws "Template is missing"
Fix : upload folder will be decided according to the extension name